### PR TITLE
Add mill module 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 inThisBuild(
   List(
-    organization := "com.indoorvivants.vcpkg", 
+    organization := "com.indoorvivants.vcpkg",
     homepage := Some(url("https://github.com/indoorvivants/sbt-vcpkg")),
     licenses := List(
       "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
@@ -24,7 +24,9 @@ lazy val supportedScalaVersions = List(scala213, scala212, scala3)
 
 lazy val root = project
   .in(file("."))
-  .aggregate((core.projectRefs ++ `sbt-plugin`.projectRefs ++ `mill-plugin`.projectRefs) *)
+  .aggregate(
+    (core.projectRefs ++ `sbt-plugin`.projectRefs ++ `mill-plugin`.projectRefs) *
+  )
   .settings(
     publish / skip := true
   )
@@ -61,7 +63,9 @@ lazy val `mill-plugin` = projectMatrix
   .dependsOn(core)
   .settings(
     name := """vcpkg-mill""",
-    libraryDependencies += "com.lihaoyi" %% "mill-scalalib" % "0.10.4"
+    libraryDependencies += "com.lihaoyi" %% "mill-scalalib" % "0.10.4",
+    libraryDependencies += "com.lihaoyi" %% "utest" % "0.7.11" % Test,
+    testFrameworks += new TestFramework("utest.runner.Framework")
   )
 
 Global / onChangedBuildSource := ReloadOnSourceChanges

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val supportedScalaVersions = List(scala213, scala212, scala3)
 
 lazy val root = project
   .in(file("."))
-  .aggregate((core.projectRefs ++ `sbt-plugin`.projectRefs) *)
+  .aggregate((core.projectRefs ++ `sbt-plugin`.projectRefs ++ `mill-plugin`.projectRefs) *)
   .settings(
     publish / skip := true
   )

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val `sbt-plugin` = projectMatrix
   .dependsOn(core)
   .enablePlugins(ScriptedPlugin)
   .settings(
-    name := """vcpkg-sbt""",
+    name := """sbt-vcpkg""",
     sbtPlugin := true,
     // set up 'scripted; sbt plugin for testing sbt plugins
     scriptedLaunchOpts ++= Seq(
@@ -62,7 +62,7 @@ lazy val `mill-plugin` = projectMatrix
   .in(file("mill-plugin"))
   .dependsOn(core)
   .settings(
-    name := """vcpkg-mill""",
+    name := """mill-vcpkg""",
     libraryDependencies += "com.lihaoyi" %% "mill-scalalib" % "0.10.4",
     libraryDependencies += "com.lihaoyi" %% "utest" % "0.7.11" % Test,
     testFrameworks += new TestFramework("utest.runner.Framework")

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 inThisBuild(
   List(
-    organization := "com.indoorvivants", // TODO : org should probably be com.indoorvivants.vcpkg
+    organization := "com.indoorvivants.vcpkg", 
     homepage := Some(url("https://github.com/indoorvivants/sbt-vcpkg")),
     licenses := List(
       "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
@@ -45,7 +45,7 @@ lazy val `sbt-plugin` = projectMatrix
   .dependsOn(core)
   .enablePlugins(ScriptedPlugin)
   .settings(
-    name := """sbt-vcpkg""",
+    name := """vcpkg-sbt""",
     sbtPlugin := true,
     // set up 'scripted; sbt plugin for testing sbt plugins
     scriptedLaunchOpts ++= Seq(
@@ -60,7 +60,7 @@ lazy val `mill-plugin` = projectMatrix
   .in(file("mill-plugin"))
   .dependsOn(core)
   .settings(
-    name := """mill-vcpkg""",
+    name := """vcpkg-mill""",
     libraryDependencies += "com.lihaoyi" %% "mill-scalalib" % "0.10.4"
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,16 @@ lazy val `sbt-plugin` = projectMatrix
       "-Xmx1024M",
       "-Dplugin.version=" + version.value
     ),
-    scriptedBufferLog := false,
+    scriptedBufferLog := false
+  )
+
+lazy val `mill-plugin` = projectMatrix
+  .jvmPlatform(scalaVersions = Seq(scala213))
+  .in(file("mill-plugin"))
+  .dependsOn(core)
+  .settings(
+    name := """mill-vcpkg""",
+    libraryDependencies += "com.lihaoyi" %% "mill-scalalib" % "0.10.4"
   )
 
 Global / onChangedBuildSource := ReloadOnSourceChanges

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ inThisBuild(
         "contact@indoorvivants.com",
         url("https://blog.indoorvivants.com")
       )
-    )
+    ),
+    version := (if (!sys.env.contains("CI")) "dev" else version.value)
   )
 )
 

--- a/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgPluginImpl.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgPluginImpl.scala
@@ -1,0 +1,108 @@
+package com.indoorvivants.vcpkg
+
+import Platform.OS._
+import java.io.File
+
+/** A bunch of build-tool agnostic functions. The trait can be mixed in SBT's or
+  * Mill's native plugin constructs, which can then delegate to these functions,
+  * keeping the build-tool-specific code down to a minimum.
+  */
+trait VcpkgPluginImpl {
+
+  def vcpkgInstallImpl(
+      dependencies: Set[String],
+      manager: Vcpkg,
+      logInfo: String => Unit
+  ): Vector[Vcpkg.FilesInfo] = {
+    val deps = dependencies.map(Vcpkg.Dependency.parse)
+
+    val allActualDependencies = deps
+      .flatMap { name =>
+        val info = manager.dependencyInfo(name.name)
+        val transitive = info.allTransitive(name)
+
+        name +: transitive
+      }
+      .filterNot(_.name.startsWith("vcpkg-"))
+
+    allActualDependencies.map { dep =>
+      logInfo(s"Installing ${dep.name}")
+      manager.install(dep.name)
+      manager.files(dep.name)
+    }.toVector
+  }
+
+  def vcpkgLinkingArgumentsImpl(
+      info: Vector[Vcpkg.FilesInfo],
+      logWarn: String => Unit
+  ): Vector[String] = {
+    val arguments = Vector.newBuilder[String]
+
+    info.foreach { case f @ Vcpkg.FilesInfo(_, libDir) =>
+      val static = f.staticLibraries
+      val dynamic = f.dynamicLibraries
+
+      if (dynamic.nonEmpty) {
+        arguments += s"-L$libDir"
+        dynamic.foreach { filePath =>
+          val fileName = baseName(filePath)
+
+          if (fileName.startsWith("lib"))
+            arguments += "-l" + fileName.drop(3)
+          else
+            logWarn(
+              s"Malformed dynamic library filename $fileName in $filePath"
+            )
+        }
+      }
+
+      static.foreach(f => arguments += f.toString)
+    }
+    arguments.result()
+  }
+
+  def vcpkgBinaryImpl(
+      targetFolder: File,
+      logInfo: String => Unit,
+      logError: String => Unit
+  ): File = {
+    val destination = targetFolder / "vcpkg"
+
+    val binary = destination / VcpkgBootstrap.BINARY_NAME
+    val bootstrapScript = destination / VcpkgBootstrap.BOOTSTRAP_SCRIPT
+
+    if (binary.exists) binary
+    else if (bootstrapScript.exists) {
+      logInfo("Bootstrapping vcpkg...")
+      VcpkgBootstrap.launchBootstrap(destination, logError)
+
+      binary
+    } else {
+      logInfo("Cloning and doing the whole shebang")
+      VcpkgBootstrap.clone(destination)
+      VcpkgBootstrap.launchBootstrap(destination, logError)
+
+      binary
+    }
+  }
+
+  def vcpkgCompilationArgumentsImpl(
+      info: Vector[Vcpkg.FilesInfo]
+  ): Vector[String] = {
+    val arguments = Vector.newBuilder[String]
+
+    info.foreach { case f @ Vcpkg.FilesInfo(includeDir, _) =>
+      arguments += s"-I$includeDir"
+    }
+
+    arguments.result()
+  }
+
+  private def baseName(file: java.io.File): String = {
+    val last = file.getName()
+    val li = last.lastIndexOf('.')
+    if (li == -1) last
+    else last.slice(0, li)
+  }
+
+}

--- a/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgPluginImpl.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgPluginImpl.scala
@@ -9,7 +9,7 @@ import java.io.File
   */
 trait VcpkgPluginImpl {
 
-  def vcpkgInstallImpl(
+  protected def vcpkgInstallImpl(
       dependencies: Set[String],
       manager: Vcpkg,
       logInfo: String => Unit
@@ -32,7 +32,7 @@ trait VcpkgPluginImpl {
     }.toVector
   }
 
-  def vcpkgLinkingArgumentsImpl(
+  protected def vcpkgLinkingArgumentsImpl(
       info: Vector[Vcpkg.FilesInfo],
       logWarn: String => Unit
   ): Vector[String] = {
@@ -61,7 +61,7 @@ trait VcpkgPluginImpl {
     arguments.result()
   }
 
-  def vcpkgBinaryImpl(
+  protected def vcpkgBinaryImpl(
       targetFolder: File,
       logInfo: String => Unit,
       logError: String => Unit
@@ -86,7 +86,7 @@ trait VcpkgPluginImpl {
     }
   }
 
-  def vcpkgCompilationArgumentsImpl(
+  protected def vcpkgCompilationArgumentsImpl(
       info: Vector[Vcpkg.FilesInfo]
   ): Vector[String] = {
     val arguments = Vector.newBuilder[String]

--- a/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/MFilesInfo.scala
+++ b/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/MFilesInfo.scala
@@ -1,0 +1,20 @@
+package com.indoorvivants.vcpkg.mill
+
+import mill._
+import upickle.default._
+import com.indoorvivants.vcpkg.Vcpkg
+
+private[vcpkg] case class MFilesInfo(includeDir: PathRef, libDir: PathRef) {
+  def toVcpkgFilesInfo: Vcpkg.FilesInfo =
+    Vcpkg.FilesInfo(includeDir.path.toIO, libDir.path.toIO)
+}
+
+private[vcpkg] object MFilesInfo {
+  def fromVcpkgFilesInfo(filesInfo: Vcpkg.FilesInfo): MFilesInfo =
+    MFilesInfo(
+      PathRef(os.Path(filesInfo.includeDir)),
+      PathRef(os.Path(filesInfo.libDir))
+    )
+
+  implicit val readWriter: ReadWriter[MFilesInfo] = macroRW[MFilesInfo]
+}

--- a/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/VcpkgModule.scala
+++ b/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/VcpkgModule.scala
@@ -1,0 +1,120 @@
+package com.indoorvivants.vcpkg.mill
+
+import mill._
+import java.util.Arrays
+import scala.sys.process
+import java.nio.file.Files
+import java.util.stream.Collectors
+import com.indoorvivants.vcpkg.Vcpkg
+import com.indoorvivants.vcpkg.VcpkgBootstrap
+import com.indoorvivants.vcpkg.Platform.OS._
+import mill.define.Worker
+import mill.define.ExternalModule
+import mill.define.Discover
+
+trait VcpkgModule extends mill.define.Module {
+
+  /** List of vcpkg dependencies
+    */
+  def vcpkgDependencies: T[Set[String]]
+
+  /** Whether to bootstrap vcpkg automatically
+    */
+  def vcpkgBootstrap: T[Boolean] = true
+
+  def vcpkgManager: Worker[Vcpkg] = T.worker {
+    val binary = VcpkgModule.vcpkgBinary().toIO
+    val installation = T.dest / "vcpkg-install"
+    val errorLogger = (s: String) => T.log.errorStream.println(s)
+    VcpkgBootstrap.manager(binary, installation.toIO, errorLogger)
+  }
+
+  def vcpkgInstall: T[List[Vcpkg.FilesInfo]] = T {
+    val deps = vcpkgDependencies().map(Vcpkg.Dependency.parse)
+    val manager = vcpkgManager()
+
+    val allActualDependencies = deps
+      .flatMap { name =>
+        val info = manager.dependencyInfo(name.name)
+        val transitive = info.allTransitive(name)
+
+        name +: transitive
+      }
+      .filterNot(_.name.startsWith("vcpkg-"))
+
+    allActualDependencies.map { dep =>
+      T.log.info(s"Installing ${dep.name}")
+      manager.install(dep.name)
+
+      manager.files(dep.name)
+    }.toList
+  }
+
+  def vcpkgLinkingArguments: T[Vector[String]] = T {
+    val info = vcpkgInstall()
+    val arguments = Vector.newBuilder[String]
+
+    info.foreach { case f @ Vcpkg.FilesInfo(_, libDir) =>
+      val static = f.staticLibraries
+      val dynamic = f.dynamicLibraries
+
+      if (dynamic.nonEmpty) {
+        arguments += s"-L$libDir"
+        dynamic.foreach { filePath =>
+          val fileName = os.Path(filePath).baseName
+
+          if (fileName.startsWith("lib"))
+            arguments += "-l" + fileName.drop(3)
+          else
+            T.log.error(
+              s"Malformed dynamic library filename $fileName in $filePath"
+            )
+        }
+      }
+
+      static.foreach(f => arguments += f.toString)
+    }
+
+    arguments.result()
+  }
+
+  def vcpkgCompilationArguments: T[Vector[String]] = T {
+    val info = vcpkgInstall()
+    val arguments = Vector.newBuilder[String]
+
+    info.foreach { case f @ Vcpkg.FilesInfo(includeDir, _) =>
+      arguments += s"-I$includeDir"
+    }
+
+    arguments.result()
+  }
+}
+
+object VcpkgModule extends ExternalModule {
+
+  /** "Path to vcpkg binary"
+    */
+  def vcpkgBinary: T[os.Path] = T {
+    val destination = T.dest / "vcpkg"
+
+    val binary = destination / VcpkgBootstrap.BINARY_NAME
+    val bootstrapScript = destination / VcpkgBootstrap.BOOTSTRAP_SCRIPT
+    val errorLogger = (s: String) => T.log.error(s)
+
+    if (os.exists(binary)) binary
+    else if (os.exists(bootstrapScript)) {
+      T.log.info("Bootstrapping vcpkg...")
+      VcpkgBootstrap.launchBootstrap(destination.toIO, errorLogger)
+
+      binary
+    } else {
+      T.log.info("Cloning and doing the whole shebang")
+      VcpkgBootstrap.clone(destination.toIO)
+      VcpkgBootstrap.launchBootstrap(destination.toIO, errorLogger)
+
+      binary
+    }
+  }
+
+  def millDiscover: Discover[this.type] = mill.define.Discover[this.type]
+}

--- a/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/package.scala
+++ b/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/package.scala
@@ -1,0 +1,9 @@
+package com.indoorvivants.vcpkg
+
+import upickle.default._
+
+package object mill {
+  implicit val filesInfoRw: ReadWriter[Vcpkg.FilesInfo] =
+    implicitly[ReadWriter[MFilesInfo]]
+      .bimap(MFilesInfo.fromVcpkgFilesInfo, _.toVcpkgFilesInfo)
+}

--- a/mill-plugin/src/test/scala/com/indoorvivants/vcpkg/mill/VcpkgModuleSpec.scala
+++ b/mill-plugin/src/test/scala/com/indoorvivants/vcpkg/mill/VcpkgModuleSpec.scala
@@ -1,0 +1,24 @@
+package com.indoorvivants.vcpkg.mill
+
+import utest._
+import mill._
+import mill.util.TestEvaluator
+import mill.util.TestUtil
+
+object VcpkgModuleSpec extends utest.TestSuite {
+
+  def tests: Tests = Tests {
+    test("foo") {
+      object build extends TestUtil.BaseModule {
+        object foo extends VcpkgModule {
+          def vcpkgDependencies = T(Set("libuv"))
+        }
+      }
+
+      val eval = new TestEvaluator(build)
+      val Right((result, _)) = eval(build.foo.vcpkgCompilationArguments)
+      assert(result.size > 0)
+    }
+  }
+
+}

--- a/mill-plugin/src/test/scala/mill/util/TestEvaluator.scala
+++ b/mill-plugin/src/test/scala/mill/util/TestEvaluator.scala
@@ -1,0 +1,132 @@
+package mill.util
+
+import java.io.{InputStream, PrintStream}
+import mill.define.{Input, Target, Task}
+import mill.api.Result.OuterStack
+import mill.eval.Evaluator
+import mill.api.Strict.Agg
+import utest.assert
+import utest.framework.TestPath
+
+import language.experimental.macros
+import mill.api.{DummyInputStream, Result}
+
+// Borrowed from the mill codebase : https://github.com/Baccata/mill/blob/master/main/test/src/util/TestEvaluator.scala
+object TestEvaluator {
+  val externalOutPath = os.pwd / "target" / "external"
+
+  def static(
+      module: => TestUtil.BaseModule
+  )(implicit fullName: sourcecode.FullName) = {
+    new TestEvaluator(module)(fullName, TestPath(Nil))
+  }
+}
+
+/** @param module
+  *   The module under test
+  * @param failFast
+  *   failFast mode enabled
+  * @param threads
+  *   explicitly used nr. of parallel threads
+  */
+class TestEvaluator(
+    module: TestUtil.BaseModule,
+    failFast: Boolean = false,
+    threads: Option[Int] = Some(1),
+    outStream: PrintStream = System.out,
+    inStream: InputStream = DummyInputStream,
+    debugEnabled: Boolean = false,
+    extraPathEnd: Seq[String] = Seq.empty
+)(implicit fullName: sourcecode.FullName, tp: TestPath) {
+  val outPath = TestUtil.getOutPath() / extraPathEnd
+
+//  val logger = DummyLogger
+  val logger = new PrintLogger(
+    colored = true,
+    disableTicker = false,
+    ammonite.util.Colors.Default.info(),
+    ammonite.util.Colors.Default.error(),
+    outStream,
+    outStream,
+    outStream,
+    inStream,
+    debugEnabled = debugEnabled,
+    context = ""
+  ) {
+    val prefix = {
+      val idx = fullName.value.lastIndexOf(".")
+      if (idx > 0) fullName.value.substring(0, idx)
+      else fullName.value
+    }
+    override def error(s: String): Unit = super.error(s"${prefix}: ${s}")
+    override def info(s: String): Unit = super.info(s"${prefix}: ${s}")
+    override def debug(s: String): Unit = super.debug(s"${prefix}: ${s}")
+    override def ticker(s: String): Unit = super.ticker(s"${prefix}: ${s}")
+  }
+  val evaluator = Evaluator(
+    mill.api.Ctx.defaultHome,
+    outPath,
+    TestEvaluator.externalOutPath,
+    module,
+    logger
+  ).withFailFast(failFast).withThreadCount(threads)
+
+  def apply[T](t: Task[T]): Either[mill.api.Result.Failing[T], (T, Int)] = {
+    val evaluated = evaluator.evaluate(Agg(t))
+
+    if (evaluated.failing.keyCount == 0) {
+      Right(
+        Tuple2(
+          evaluated.rawValues.head.asInstanceOf[Result.Success[T]].value,
+          evaluated.evaluated.collect {
+            case t: Target[_]
+                if module.millInternal.targets.contains(t)
+                  && !t.isInstanceOf[Input[_]]
+                  && !t.ctx.external =>
+              t
+            case t: mill.define.Command[_] => t
+          }.size
+        )
+      )
+    } else {
+      Left(
+        evaluated.failing
+          .lookupKey(evaluated.failing.keys().next)
+          .items
+          .next()
+          .asInstanceOf[Result.Failing[T]]
+      )
+    }
+  }
+
+  def fail(
+      target: Target[_],
+      expectedFailCount: Int,
+      expectedRawValues: Seq[Result[_]]
+  ): Unit = {
+
+    val res = evaluator.evaluate(Agg(target))
+
+    val cleaned = res.rawValues.map {
+      case Result.Exception(ex, _) => Result.Exception(ex, new OuterStack(Nil))
+      case x                       => x
+    }
+
+    assert(
+      cleaned == expectedRawValues,
+      res.failing.keyCount == expectedFailCount
+    )
+
+  }
+
+  def check(targets: Agg[Task[_]], expected: Agg[Task[_]]): Unit = {
+    val evaluated = evaluator
+      .evaluate(targets)
+      .evaluated
+      .flatMap(_.asTarget)
+      .filter(module.millInternal.targets.contains)
+      .filter(!_.isInstanceOf[Input[_]])
+    assert(evaluated == expected)
+  }
+
+}

--- a/mill-plugin/src/test/scala/mill/util/TestUtil.scala
+++ b/mill-plugin/src/test/scala/mill/util/TestUtil.scala
@@ -1,0 +1,88 @@
+package mill.util
+
+import mill.define._
+import mill.api.Result
+import mill.api.Result.OuterStack
+import utest.assert
+import mill.api.Strict.Agg
+import utest.framework.TestPath
+
+import scala.collection.mutable
+
+// Borrowed from the mill codebase : https://github.com/Baccata/mill/blob/master/main/test/src/util/TestEvaluator.scala
+object TestUtil {
+  def getOutPath()(implicit
+      fullName: sourcecode.FullName,
+      tp: TestPath
+  ): os.Path = {
+    getOutPathStatic() / tp.value
+  }
+  def getOutPathStatic()(implicit fullName: sourcecode.FullName): os.Path = {
+    os.pwd / "target" / "workspace" / fullName.value.split('.')
+  }
+
+  def getSrcPathStatic()(implicit fullName: sourcecode.FullName): os.Path = {
+    getSrcPathBase() / fullName.value.split('.')
+  }
+  def getSrcPathBase(): os.Path = {
+    os.pwd / "target" / "worksources"
+  }
+
+  class BaseModule(implicit
+      millModuleEnclosing0: sourcecode.Enclosing,
+      millModuleLine0: sourcecode.Line,
+      millName0: sourcecode.Name
+  ) extends mill.define.BaseModule(
+        getSrcPathBase() / millModuleEnclosing0.value.split("\\.| |#")
+      )(
+        implicitly,
+        implicitly,
+        implicitly,
+        implicitly,
+        implicitly
+      ) {
+    lazy val millDiscover: Discover[this.type] = Discover[this.type]
+  }
+
+  object test {
+
+    def anon(inputs: Task[Int]*) = new Test(inputs)
+    def apply(inputs: Task[Int]*)(implicit ctx: mill.define.Ctx) = {
+      new TestTarget(inputs, pure = inputs.nonEmpty)
+    }
+  }
+
+  class Test(val inputs: Seq[Task[Int]]) extends Task[Int] {
+    var counter = 0
+    var failure = Option.empty[String]
+    var exception = Option.empty[Throwable]
+    override def evaluate(args: mill.api.Ctx) = {
+      failure.map(Result.Failure(_)) orElse
+        exception.map(Result.Exception(_, new OuterStack(Nil))) getOrElse
+        Result.Success(counter + args.args.map(_.asInstanceOf[Int]).sum)
+    }
+    override def sideHash = counter + failure.hashCode() + exception.hashCode()
+  }
+
+  /** A dummy target that takes any number of inputs, and whose output can be
+    * controlled externally, so you can construct arbitrary dataflow graphs and
+    * test how changes propagate.
+    */
+  class TestTarget(inputs: Seq[Task[Int]], val pure: Boolean)(implicit
+      ctx0: mill.define.Ctx
+  ) extends Test(inputs)
+      with Target[Int] {
+    val ctx = ctx0.copy(segments = ctx0.segments ++ Seq(ctx0.segment))
+    val readWrite = upickle.default.readwriter[Int]
+
+  }
+  def checkTopological(targets: Agg[Task[_]]) = {
+    val seen = mutable.Set.empty[Task[_]]
+    for (t <- targets.indexed.reverseIterator) {
+      seen.add(t)
+      for (upstream <- t.inputs) {
+        assert(!seen(upstream))
+      }
+    }
+  }
+}

--- a/sbt-plugin/src/sbt-test/sbt-vcpkg/simple/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-vcpkg/simple/project/plugins.sbt
@@ -3,5 +3,5 @@
   if(pluginVersion == null)
     throw new RuntimeException("""|The system property 'plugin.version' is not defined.
                                   |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
-  else addSbtPlugin("com.indoorvivants" % """sbt-vcpkg""" % pluginVersion)
+  else addSbtPlugin("com.indoorvivants.vcpkg" % """sbt-vcpkg""" % pluginVersion)
 }


### PR DESCRIPTION
Adds a mill module 

* factors most of the logic away from the SBT module, in a way that makes SBT and mill usage consistent 
* adds a mill module 
* adds unit tests for the mill module 
* renames maven org to `com.indoorvivants.vcpkg` (to make it easier for Anton to get relevant stats from sonatype)  

Addresses https://github.com/indoorvivants/sbt-vcpkg/issues/5
