### PR TITLE
pkg-config for compilation/linking arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,17 @@ jobs:
       - name: Setup git config
         run: git config --global core.autocrlf false
         if: runner.os == 'Windows'
-      
-      - name: Configure Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.2
-        with:
-          minimum-size: 4GB
-          maximum-size: 16GB
+
+      - name: Install pkg-config on Windows
+        run: choco install pkgconfiglite
         if: runner.os == 'Windows'
+      
+      # - name: Configure Pagefile
+      #   uses: al-cheb/configure-pagefile-action@v1.2
+      #   with:
+      #     minimum-size: 4GB
+      #     maximum-size: 16GB
+      #   if: runner.os == 'Windows'
       
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-11]
+        os: [ubuntu-20.04, macos-11, windows-2019]
         java: [11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -42,7 +42,11 @@ jobs:
           java-version: '${{ matrix.java }}'
       
       - name: Test
-        run: sbt test scripted
+        run: sbt test
+
+      - name: Scripted tests
+        run: sbt scripted
+        if: runner.os != 'Windows'
 
   release:
     name: Release

--- a/core/src/main/scala/CommandParser.scala
+++ b/core/src/main/scala/CommandParser.scala
@@ -1,0 +1,120 @@
+// The code below is copied from scala/scala: 
+// https://github.com/scala/scala/blob/2.13.x/src/library/scala/sys/process/Parser.scala
+// following changes were applied (original copyright retained)
+//
+// 1. Package was changed from scala.sys.process to com.indoorvivants.pkg
+// 2. Parser was renamed to CommandParser 
+// 3. private[scala] was removed
+
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package com.indoorvivants.vcpkg
+
+import scala.annotation.tailrec
+
+/** A simple enough command line parser.
+ */
+object CommandParser {
+  private final val DQ = '"'
+  private final val SQ = '\''
+
+  /** Split the line into tokens separated by whitespace or quotes.
+   *
+   *  @return either an error message or reverse list of tokens
+   */
+  private def tokens(in: String) = {
+    import Character.isWhitespace
+    import java.lang.{StringBuilder => Builder}
+    import collection.mutable.ArrayBuffer
+
+    var accum: List[String] = Nil
+    var pos = 0
+    var start = 0
+    val qpos = new ArrayBuffer[Int](16)    // positions of paired quotes
+
+    def cur: Int  = if (done) -1 else in.charAt(pos)
+    def bump() = pos += 1
+    def done   = pos >= in.length
+
+    def skipToQuote(q: Int) = {
+      var escaped = false
+      def terminal = in.charAt(pos) match {
+        case _ if escaped => escaped = false ; false
+        case '\\'         => escaped = true ; false
+        case `q`          => true
+        case _            => false
+      }
+      while (!done && !terminal) pos += 1
+      !done
+    }
+    @tailrec
+    def skipToDelim(): Boolean =
+      cur match {
+        case q @ (DQ | SQ)        => { qpos += pos; bump(); skipToQuote(q) } && { qpos += pos; bump(); skipToDelim() }
+        case -1                   => true
+        case c if isWhitespace(c) => true
+        case _                    => bump(); skipToDelim()
+      }
+    def skipWhitespace() = while (isWhitespace(cur)) pos += 1
+    def copyText() = {
+      val buf = new Builder
+      var p = start
+      var i = 0
+      while (p < pos) {
+        if (i >= qpos.size) {
+          buf.append(in, p, pos)
+          p = pos
+        } else if (p == qpos(i)) {
+          buf.append(in, qpos(i)+1, qpos(i+1))
+          p = qpos(i+1)+1
+          i += 2
+        } else {
+          buf.append(in, p, qpos(i))
+          p = qpos(i)
+        }
+      }
+      buf.toString
+    }
+    def text() = {
+      val res =
+        if (qpos.isEmpty) in.substring(start, pos)
+        else if (qpos(0) == start && qpos(1) == pos) in.substring(start+1, pos-1)
+        else copyText()
+      qpos.clear()
+      res
+    }
+    def badquote = Left("Unmatched quote")
+
+    @tailrec def loop(): Either[String, List[String]] = {
+      skipWhitespace()
+      start = pos
+      if (done) Right(accum)
+      else if (!skipToDelim()) badquote
+      else {
+        accum = text() :: accum
+        loop()
+      }
+    }
+    loop()
+  }
+
+  class ParseException(msg: String) extends RuntimeException(msg)
+
+  def tokenize(line: String, errorFn: String => Unit): List[String] =
+    tokens(line) match {
+      case Right(args) => args.reverse
+      case Left(msg)   => errorFn(msg) ; Nil
+    }
+
+  def tokenize(line: String): List[String] = tokenize(line, x => throw new ParseException(x))
+}

--- a/core/src/main/scala/com/indoorvivants/vcpkg/PkgConfig.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/PkgConfig.scala
@@ -1,0 +1,48 @@
+package com.indoorvivants.vcpkg
+
+import java.io.File
+
+class PkgConfig(baseDir: File, error: String => Unit, debug: String => Unit) {
+  def compilationFlags(packages: String*): Seq[String] =
+    updateCompilationFlags(Seq.empty, packages *)
+
+  def linkingFlags(packages: String*): Seq[String] =
+    updateLinkingFlags(Seq.empty, packages *)
+
+  private val env = Map("PKG_CONFIG_PATH" -> baseDir.toString)
+
+  private def getLines(args: Seq[String]) = {
+    import sys.process.Process
+    val logs = Vcpkg.logCollector()
+    val p = Process
+      .apply(args, cwd = None, extraEnv = env.toSeq *)
+      .run(logs.logger)
+      .exitValue()
+
+    if (p != 0) {
+      logs.dump(error)
+      error(s"PkgConfig env: $env")
+      commandFailed(args, p, env)
+    } else {
+      logs.dump(debug)
+      logs.stdout()
+    }
+  }
+
+  def updateCompilationFlags(
+      current: Seq[String],
+      packages: String*
+  ): Seq[String] = {
+    val cmd = Seq("pkg-config", "--cflags") ++ packages
+    getLines(cmd).flatMap(CommandParser.tokenize(_)).filterNot(current.contains)
+  }
+
+  def updateLinkingFlags(
+      current: Seq[String],
+      packages: String*
+  ): Seq[String] = {
+    val cmd = Seq("pkg-config", "--libs") ++ packages
+    getLines(cmd).flatMap(CommandParser.tokenize(_)).filterNot(current.contains)
+  }
+
+}

--- a/core/src/main/scala/com/indoorvivants/vcpkg/PkgConfig.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/PkgConfig.scala
@@ -1,8 +1,18 @@
 package com.indoorvivants.vcpkg
 
 import java.io.File
+import com.indoorvivants.vcpkg.Platform.OS.Linux
+import com.indoorvivants.vcpkg.Platform.OS.MacOS
+import com.indoorvivants.vcpkg.Platform.OS.Unknown
+import com.indoorvivants.vcpkg.Platform.OS.Windows
 
 class PkgConfig(baseDir: File, error: String => Unit, debug: String => Unit) {
+
+  lazy val binaryName = Platform.os match {
+    case Windows => "pkg-config.exe"
+    case _       => "pkg-config"
+  }
+
   def compilationFlags(packages: String*): Seq[String] =
     updateCompilationFlags(Seq.empty, packages *)
 
@@ -33,7 +43,7 @@ class PkgConfig(baseDir: File, error: String => Unit, debug: String => Unit) {
       current: Seq[String],
       packages: String*
   ): Seq[String] = {
-    val cmd = Seq("pkg-config", "--cflags") ++ packages
+    val cmd = Seq(binaryName, "--cflags") ++ packages
     getLines(cmd).flatMap(CommandParser.tokenize(_)).filterNot(current.contains)
   }
 
@@ -41,7 +51,7 @@ class PkgConfig(baseDir: File, error: String => Unit, debug: String => Unit) {
       current: Seq[String],
       packages: String*
   ): Seq[String] = {
-    val cmd = Seq("pkg-config", "--libs") ++ packages
+    val cmd = Seq(binaryName, "--libs") ++ packages
     getLines(cmd).flatMap(CommandParser.tokenize(_)).filterNot(current.contains)
   }
 

--- a/core/src/main/scala/com/indoorvivants/vcpkg/Vcpkg.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/Vcpkg.scala
@@ -174,23 +174,51 @@ object Vcpkg {
       else Vector.empty
 
     def staticLibraries = {
-      val extension = Platform.os match {
-        case Windows => ".lib"
-        case _       => ".a"
-      }
-      walk(libDir.toPath, _.getFileName.toString.endsWith(extension))
+      walk(
+        libDir.toPath,
+        _.getFileName.toString.endsWith(FilesInfo.staticLibExtension)
+      )
     }
 
     def dynamicLibraries = {
-      val extension = Platform.os match {
-        case Linux | Unknown => ".so"
-        case MacOS           => ".dylib"
-        case Windows         => ".dll"
-      }
-      walk(libDir.toPath, _.getFileName.toString.endsWith(extension))
+      walk(
+        libDir.toPath,
+        _.getFileName.toString.endsWith(FilesInfo.dynamicLibExtension)
+      )
     }
 
     def pkgConfigDir = libDir / "pkgconfig"
+  }
+
+  object FilesInfo {
+    lazy val dynamicLibExtension = Platform.os match {
+      case Linux | Unknown => ".so"
+      case MacOS           => ".dylib"
+      case Windows         => ".dll"
+    }
+
+    lazy val staticLibExtension = Platform.os match {
+      case Windows => ".lib"
+      case _       => ".a"
+    }
+
+    def dynamicLibName(name: String) = {
+      val base = Platform.os match {
+        case Linux | Unknown | MacOS => "lib" + name
+        case Windows                 => name
+      }
+
+      base + dynamicLibExtension
+    }
+
+    def staticLibName(name: String) = {
+      val base = Platform.os match {
+        case Linux | Unknown | MacOS => "lib" + name
+        case Windows                 => name
+      }
+
+      base + staticLibExtension
+    }
   }
 
   case class Logs(

--- a/core/src/main/scala/com/indoorvivants/vcpkg/package.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/package.scala
@@ -10,4 +10,20 @@ package object vcpkg {
       file.toPath.resolve(s).toFile
   }
 
+  private[vcpkg] def commandFailed(
+      args: Seq[String],
+      code: Int,
+      extraEnv: Map[String, String] = Map.empty
+  ) = {
+    val command = args.mkString("`", " ", "`")
+    val env =
+      if (extraEnv.nonEmpty)
+        ", env: " + extraEnv.toSeq
+          .sortBy(_._1)
+          .map { case (k, v) => s"$k=$v" }
+          .mkString(", ")
+      else ""
+    throw new Exception(s"Command $command failed with exit code $code$env")
+  }
+
 }

--- a/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/VcpkgModule.scala
+++ b/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/VcpkgModule.scala
@@ -1,17 +1,19 @@
 package com.indoorvivants.vcpkg.mill
 
-import mill._
-import java.util.Arrays
-import scala.sys.process
-import java.nio.file.Files
-import java.util.stream.Collectors
+import com.indoorvivants.vcpkg.PkgConfig
+import com.indoorvivants.vcpkg.Platform.OS._
 import com.indoorvivants.vcpkg.Vcpkg
 import com.indoorvivants.vcpkg.VcpkgBootstrap
-import com.indoorvivants.vcpkg.Platform.OS._
-import mill.define.Worker
-import mill.define.ExternalModule
-import mill.define.Discover
 import com.indoorvivants.vcpkg.VcpkgPluginImpl
+import mill._
+import mill.define.Discover
+import mill.define.ExternalModule
+import mill.define.Worker
+
+import java.nio.file.Files
+import java.util.Arrays
+import java.util.stream.Collectors
+import scala.sys.process
 
 trait VcpkgModule extends mill.define.Module with VcpkgPluginImpl {
 
@@ -24,6 +26,11 @@ trait VcpkgModule extends mill.define.Module with VcpkgPluginImpl {
   def vcpkgBootstrap: T[Boolean] = true
 
   def vcpkgBaseDir: T[os.Path] = os.Path(vcpkgDefaultBaseDir)
+
+  def vcpkgConfigurator: Worker[PkgConfig] = T.worker {
+    vcpkgInstall()
+    vcpkgManager().pkgConfig
+  }
 
   /** "Path to vcpkg binary"
     */

--- a/mill-plugin/src/test/scala/com/indoorvivants/vcpkg/mill/VcpkgModuleSpec.scala
+++ b/mill-plugin/src/test/scala/com/indoorvivants/vcpkg/mill/VcpkgModuleSpec.scala
@@ -8,7 +8,7 @@ import mill.util.TestUtil
 object VcpkgModuleSpec extends utest.TestSuite {
 
   def tests: Tests = Tests {
-    test("foo") {
+    test("base") {
       object build extends TestUtil.BaseModule {
         object foo extends VcpkgModule {
           def vcpkgDependencies = T(Set("libuv"))
@@ -18,6 +18,27 @@ object VcpkgModuleSpec extends utest.TestSuite {
       val eval = new TestEvaluator(build)
       val Right((result, _)) = eval(build.foo.vcpkgCompilationArguments)
       assert(result.size > 0)
+    }
+
+    test("pkg-config") {
+      object build extends TestUtil.BaseModule {
+        object foo extends VcpkgModule {
+          def vcpkgDependencies = T(Set("libuv", "cjson"))
+        }
+      }
+
+      val eval = new TestEvaluator(build)
+      val Right((pkgConfig, _)) = eval(build.foo.vcpkgConfigurator)
+
+      assert(
+        pkgConfig.compilationFlags("libuv").exists(_.contains("libuv"))
+      )
+      assert(
+        pkgConfig
+          .compilationFlags("libcjson")
+          .exists(_.contains("cjson"))
+      )
+
     }
   }
 

--- a/mill-plugin/src/test/scala/com/indoorvivants/vcpkg/mill/VcpkgModuleSpec.scala
+++ b/mill-plugin/src/test/scala/com/indoorvivants/vcpkg/mill/VcpkgModuleSpec.scala
@@ -45,7 +45,8 @@ object VcpkgModuleSpec extends utest.TestSuite {
       assert(
         paths.exists { p =>
           (p / Vcpkg.FilesInfo.dynamicLibName("cmark")).toIO.exists() ||
-          (p / Vcpkg.FilesInfo.staticLibName("cmark")).toIO.exists()
+          (p / Vcpkg.FilesInfo.staticLibName("cmark")).toIO.exists() ||
+          (p / Vcpkg.FilesInfo.staticLibName("cmark_static")).toIO.exists()
         }
       )
       assert(

--- a/sbt-plugin/src/main/scala/com/indoorvivants/vcpkg/sbt/VcpkgPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/indoorvivants/vcpkg/sbt/VcpkgPlugin.scala
@@ -1,16 +1,17 @@
 package com.indoorvivants.vcpkg.sbt
 
-import sbt._
-import sbt.Keys._
-import sbt.plugins.JvmPlugin
-import java.util.Arrays
-import scala.sys.process
-import java.nio.file.Files
-import java.util.stream.Collectors
+import com.indoorvivants.vcpkg
+import com.indoorvivants.vcpkg.Platform.OS._
 import com.indoorvivants.vcpkg.Vcpkg
 import com.indoorvivants.vcpkg.VcpkgBootstrap
-import com.indoorvivants.vcpkg.Platform.OS._
-import com.indoorvivants.vcpkg
+import sbt.Keys._
+import sbt._
+import sbt.plugins.JvmPlugin
+
+import java.nio.file.Files
+import java.util.Arrays
+import java.util.stream.Collectors
+import scala.sys.process
 
 object VcpkgPlugin extends AutoPlugin with vcpkg.VcpkgPluginImpl {
 
@@ -24,6 +25,7 @@ object VcpkgPlugin extends AutoPlugin with vcpkg.VcpkgPluginImpl {
     val vcpkgLinkingArguments = settingKey[Vector[String]]("")
     val vcpkgCompilationArguments = settingKey[Vector[String]]("")
     val vcpkgManager = settingKey[Vcpkg]("")
+    val vcpkgConfigurator = settingKey[vcpkg.PkgConfig]("")
     val vcpkgBaseDir = settingKey[File]("")
   }
 
@@ -45,6 +47,11 @@ object VcpkgPlugin extends AutoPlugin with vcpkg.VcpkgPluginImpl {
         errorLogger = errorLogger,
         debugLogger = debugLogger
       )
+    },
+    vcpkgConfigurator := {
+      val _ = vcpkgInstall.value
+
+      vcpkgManager.value.pkgConfig
     },
     vcpkgBinary := {
       vcpkgBinaryImpl(

--- a/sbt-plugin/src/sbt-test/sbt-vcpkg/simple/build.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-vcpkg/simple/build.sbt
@@ -4,3 +4,18 @@ scalaVersion := "2.12.15"
 enablePlugins(VcpkgPlugin)
 
 vcpkgDependencies := Set("libuv", "cjson")
+
+val testPkgConfig = taskKey[Unit]("")
+
+testPkgConfig := {
+  val pkgConfig = vcpkgConfigurator.value
+
+  val compilation = pkgConfig.compilationFlags("libuv", "libcjson")
+  val linking = pkgConfig.linkingFlags("libuv", "libcjson")
+
+  assert(compilation.exists(_.contains("cjson")))
+  assert(compilation.exists(_.contains("libuv")))
+
+  assert(linking.exists(_.contains("-luv")))
+  assert(linking.exists(_.contains("-lcjson")))
+}

--- a/sbt-plugin/src/sbt-test/sbt-vcpkg/simple/build.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-vcpkg/simple/build.sbt
@@ -3,19 +3,51 @@ scalaVersion := "2.12.15"
 
 enablePlugins(VcpkgPlugin)
 
-vcpkgDependencies := Set("libuv", "cjson")
+import com.indoorvivants.vcpkg.Vcpkg
+
+vcpkgDependencies := Set("cmark", "cjson")
 
 val testPkgConfig = taskKey[Unit]("")
 
 testPkgConfig := {
   val pkgConfig = vcpkgConfigurator.value
 
-  val compilation = pkgConfig.compilationFlags("libuv", "libcjson")
-  val linking = pkgConfig.linkingFlags("libuv", "libcjson")
+  val compilation = pkgConfig.compilationFlags("libcmark", "libcjson")
+  val linking = pkgConfig.linkingFlags("libcmark", "libcjson")
 
-  assert(compilation.exists(_.contains("cjson")))
-  assert(compilation.exists(_.contains("libuv")))
+  val includes =
+    includePaths(compilation)
 
-  assert(linking.exists(_.contains("-luv")))
-  assert(linking.exists(_.contains("-lcjson")))
+  val libNames =
+    dynamicLibs(linking)
+
+  val paths = libPaths(linking)
+
+  assert(includes.exists(p => (p / "cmark.h").exists()))
+  assert(includes.exists(p => (p / "cJSON.h").exists()))
+
+  assert(
+    paths.exists { p =>
+      (p / Vcpkg.FilesInfo.dynamicLibName("cmark")).exists() ||
+      (p / Vcpkg.FilesInfo.staticLibName("cmark")).exists()
+    }
+  )
+  assert(
+    paths.exists { p =>
+      (p / Vcpkg.FilesInfo.dynamicLibName("cjson")).exists() ||
+      (p / Vcpkg.FilesInfo.staticLibName("cjson")).exists()
+    }
+  )
+
+  assert(libNames.contains("cmark"))
+  assert(libNames.contains("cjson"))
 }
+
+def includePaths(args: Seq[String]) =
+  args.collect { case s if s.startsWith("-I") => new File(s.drop(2)) }
+
+def dynamicLibs(args: Seq[String]) =
+  args.collect { case s if s.startsWith("-l") => s.drop(2) }
+
+def libPaths(args: Seq[String]) =
+  args.collect { case s if s.startsWith("-L") => new File(s.drop(2)) }

--- a/sbt-plugin/src/sbt-test/sbt-vcpkg/simple/test
+++ b/sbt-plugin/src/sbt-test/sbt-vcpkg/simple/test
@@ -1,2 +1,3 @@
 > vcpkgCompilationArguments
 > vcpkgLinkingArguments
+> testPkgConfig


### PR DESCRIPTION
Closes #18 
Closes #4 

Very basic/hacky integration with pkg-config.

The main goal is to rely on package's own understanding of what it needs to compile/link. With changes in this PR even for a library as huge as GTK, your `nativeConfig` definition can look like this:

```scala
vcpkgDependencies := Set("gtk")

nativeConfig := {
  val conf = nativeConfig.value
  val pkgConfig = vcpkgConfigurator.value

  conf
    .withCompileOptions(
      pkgConfig.updateCompilationFlags(conf.compileOptions, "gtk4")
    )
    .withLinkingOptions(
      pkgConfig.updateLinkingFlags(conf.linkingOptions, "gtk4")
    )
}
```

And yes, of course gtk4 is different from vcpkg's package name.

And for binding builder:

```scala
import bindgen.interface.Binding

bindgenBindings := {
  val manager = vcpkgManager.value
  val pkgConfig = vcpkgConfigurator.value
  Seq(
    Binding(
      manager.includes("gtk") / "gtk-4.0" / "gtk" / "gtk.h",
      "gtk",
      cImports = List("gtk/gtk.h"),
      clangFlags = pkgConfig.compilationFlags("gtk4").toList
    )
  )
}
```

Unfortunately binding generator breaks on GTK about halfway through, but the flags passed in are sufficient for clang to parse the entire file.

In comparison, here's what you had to manually add to attempt to compile gtk:

```scala 
def allTheFuckingIncludes(manager: com.indoorvivants.vcpkg.Vcpkg) = {
  val gtk = manager.includes("gtk") / "gtk-4.0"
  val glib = manager.includes("glib") / "glib-2.0"
  val cairo = manager.includes("cairo") / "cairo"
  val glibOther = manager.files("glib").libDir / "glib-2.0" / "include"

  List(
    gtk,
    glib,
    glibOther,
    cairo,
    manager.includes("pango") / "pango-1.0",
    manager.includes("harfbuzz") / "harfbuzz",
    manager.includes("gdk-pixbuf") / "gdk-pixbuf-2.0",
    manager.includes("graphene") / "graphene-1.0",
    manager.files("graphene").libDir / "graphene-1.0" / "include"
  )
    .map(_.toString)
    .map("-I" + _)
}
```