### PR TITLE
Synchronise vcpkg access

### DIFF
--- a/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgPluginImpl.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgPluginImpl.scala
@@ -47,7 +47,9 @@ trait VcpkgPluginImpl {
 
     allActualDependencies.map { dep =>
       logInfo(s"Installing ${dep.name}")
-      manager.install(dep.name)
+      VcpkgPluginImpl.synchronized {
+        manager.install(dep.name)
+      }
       manager.files(dep.name)
     }.toVector
   }
@@ -94,13 +96,17 @@ trait VcpkgPluginImpl {
     if (binary.exists) binary
     else if (bootstrapScript.exists) {
       logInfo("Bootstrapping vcpkg...")
-      VcpkgBootstrap.launchBootstrap(destination, logError)
+      VcpkgPluginImpl.synchronized {
+        VcpkgBootstrap.launchBootstrap(destination, logError)
+      }
 
       binary
     } else {
       logInfo(s"Cloning microsoft/vcpkg into $destination")
-      VcpkgBootstrap.clone(destination)
-      VcpkgBootstrap.launchBootstrap(destination, logError)
+      VcpkgPluginImpl.synchronized {
+        VcpkgBootstrap.clone(destination)
+        VcpkgBootstrap.launchBootstrap(destination, logError)
+      }
 
       binary
     }
@@ -126,3 +132,5 @@ trait VcpkgPluginImpl {
   }
 
 }
+
+object VcpkgPluginImpl


### PR DESCRIPTION
Turns out VCPKG is very sensitive to concurrent modifications.

I can't make any of these settings into SBT tasks, because Scala Native's nativeConfig is a setting :-/ 

So this seems to be the only way.