### PR TITLE
Synchronise access to dependency-info

### DIFF
--- a/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgPluginImpl.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgPluginImpl.scala
@@ -38,7 +38,7 @@ trait VcpkgPluginImpl {
 
     val allActualDependencies = deps
       .flatMap { name =>
-        val info = manager.dependencyInfo(name.name)
+        val info = VcpkgPluginImpl.synchronized(manager.dependencyInfo(name.name))
         val transitive = info.allTransitive(name)
 
         name +: transitive


### PR DESCRIPTION
Another bandaid, really.

Vcpkg (or cmake?) crash even during concurrent access to dependency-info.