### PR TITLE
Refactor tasks and logging, increase configurator interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,31 @@ env:
 
 jobs:
   build:
-    name: CI ${{ matrix.os }} 
+    name: Unix CI ${{ matrix.os }} 
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, macos-11]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin' 
+          java-version: 17
+          cache: sbt
+      
+      - name: Test
+        run: sbt test
+
+      - name: Scripted tests
+        run: sbt scripted
+
+      - name: Cold start tests (docker)
+        run: docker build . -t sbt-vcpkg-tests
+        if: matrix.os == 'ubuntu-20.04'
+
+  windows_build:
+    name: Windows CI
     strategy:
       fail-fast: false
       matrix:
@@ -22,11 +46,9 @@ jobs:
     steps:
       - name: Setup git config
         run: git config --global core.autocrlf false
-        if: runner.os == 'Windows'
 
       - name: Install pkg-config on Windows
         run: choco install pkgconfiglite
-        if: runner.os == 'Windows'
       
       # - name: Configure Pagefile
       #   uses: al-cheb/configure-pagefile-action@v1.2
@@ -46,17 +68,21 @@ jobs:
       - name: Test
         run: sbt test
 
-      - name: Scripted tests
-        run: sbt scripted
-        if: runner.os != 'Windows'
-
       - name: Cold start tests (docker)
         run: docker build . -t sbt-vcpkg-tests
         if: matrix.os == 'ubuntu-20.04'
 
+  summary:
+    name: Build summary
+    runs-on: ubuntu-latest
+    needs: [build, windows_build]
+    steps:
+      - name: I only exist to please Mergify :(
+        run: echo "It's a sad existence but necessary"
+
   release:
     name: Release
-    needs: [build]
+    needs: [build, windows_build]
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         os: [ubuntu-20.04, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v3
+
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin' 
@@ -40,10 +42,10 @@ jobs:
     name: Windows CI
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2019
     steps:
+      - uses: actions/checkout@v3
+
       - name: Setup git config
         run: git config --global core.autocrlf false
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,7 @@ pull_request_rules:
     conditions:
       - author=indoorvivants-steward[bot]
       - body~=labels:.*semver-patch.*
-      - status-success=build
+      - status-success=summary
     actions:
       merge:
         method: merge

--- a/core/src/main/scala/com/indoorvivants/vcpkg/ExternalLogger.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/ExternalLogger.scala
@@ -1,0 +1,8 @@
+package com.indoorvivants.vcpkg
+
+case class ExternalLogger(
+    debug: String => Unit,
+    info: String => Unit,
+    warn: String => Unit,
+    error: String => Unit
+)

--- a/core/src/main/scala/com/indoorvivants/vcpkg/PkgConfig.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/PkgConfig.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import com.indoorvivants.detective.Platform
 
-class PkgConfig(baseDir: File, error: String => Unit, debug: String => Unit) {
+class PkgConfig(baseDir: File, logger: ExternalLogger) {
 
   lazy val binaryName = Platform.os match {
     case Platform.OS.Windows => "pkg-config.exe"
@@ -28,11 +28,11 @@ class PkgConfig(baseDir: File, error: String => Unit, debug: String => Unit) {
       .exitValue()
 
     if (p != 0) {
-      logs.dump(error)
-      error(s"PkgConfig env: $env")
+      logs.dump(logger.error)
+      logger.error(s"PkgConfig env: $env")
       commandFailed(args, p, env)
     } else {
-      logs.dump(debug)
+      logs.dump(logger.debug)
       logs.stdout()
     }
   }

--- a/core/src/main/scala/com/indoorvivants/vcpkg/Vcpkg.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/Vcpkg.scala
@@ -27,7 +27,7 @@ class Vcpkg(
   private def cmd(args: String*) =
     Seq(binary.toString) ++ args ++ Seq(localArg)
 
-  private def getLines(args: Seq[String]) = {
+  private def getLines(args: Seq[String]): Vector[String] = {
     import sys.process.Process
     val logs = Vcpkg.logCollector(
       out = Set(Vcpkg.Logs.Buffer, Vcpkg.Logs.Redirect(logger.debug)),
@@ -44,10 +44,10 @@ class Vcpkg(
     }
   }
 
-  def dependencyInfo(name: String) =
+  def dependencyInfo(name: String): Vcpkg.Dependencies =
     Vcpkg.Dependencies.parse(getLines(cmd("depend-info", name)))
 
-  def install(name: String) =
+  def install(name: String): Vector[String] =
     getLines(cmd("install", name, s"--triplet=$vcpkgTriplet", "--recurse"))
 
 }
@@ -103,6 +103,7 @@ object Vcpkg {
 
   case class Dependency(name: String, features: List[String])
   object Dependency {
+    def apply(name: String): Dependency = new Dependency(name, features = Nil)
     def parse(s: String): Dependency =
       if (!s.contains('[')) Dependency(s, Nil)
       else {

--- a/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgBootstrap.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgBootstrap.scala
@@ -58,8 +58,7 @@ object VcpkgBootstrap {
   def manager(
       binary: File,
       installationDir: File,
-      errorLogger: String => Unit,
-      debugLogger: String => Unit = _ => ()
+      logger: ExternalLogger
   ) = {
     assert(
       binary.exists(),
@@ -72,6 +71,6 @@ object VcpkgBootstrap {
       linking = Vcpkg.Linking.Static
     )
 
-    new Vcpkg(config, error = errorLogger, debug = debugLogger)
+    new Vcpkg(config, logger)
   }
 }

--- a/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgConfigurator.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgConfigurator.scala
@@ -1,0 +1,69 @@
+package com.indoorvivants.vcpkg
+
+import com.indoorvivants.detective.Platform
+
+class VcpkgConfigurator(
+    config: Vcpkg.Configuration,
+    info: Map[Vcpkg.Dependency, Vcpkg.FilesInfo],
+    logger: ExternalLogger
+) {
+  import config.*
+
+  def files(name: Vcpkg.Dependency) =
+    info(name)
+
+  def includes(library: Vcpkg.Dependency) = {
+    info(library).includeDir
+  }
+
+  def approximateLinkingArguments = {
+    val arguments = Vector.newBuilder[String]
+
+    sorted.foreach { case (name, f @ Vcpkg.FilesInfo(_, libDir)) =>
+      val static = f.staticLibraries
+      val dynamic = f.dynamicLibraries
+
+      if (dynamic.nonEmpty) {
+        arguments += s"-L$libDir"
+        dynamic.foreach { filePath =>
+          val fileName = baseName(filePath)
+
+          if (fileName.startsWith("lib"))
+            arguments += "-l" + fileName.drop(3)
+          else
+            logger.warn(
+              s"Malformed dynamic library filename $fileName in $filePath"
+            )
+        }
+      }
+
+      static.foreach(f => arguments += f.toString)
+    }
+    arguments.result()
+  }
+
+  def approximateCompilationArguments = {
+    val arguments = Vector.newBuilder[String]
+
+    sorted.foreach { case (_, f @ Vcpkg.FilesInfo(includeDir, _)) =>
+      arguments += s"-I$includeDir"
+    }
+
+    arguments.result()
+  }
+
+  def pkgConfig = new PkgConfig(pkgConfigDir, logger)
+
+  private val sorted = info.toList.sortBy(_._1.name)
+  private lazy val vcpkgTriplet = config.vcpkgTriplet(Platform.target)
+  private val libDir = installationDir / vcpkgTriplet / "lib"
+
+  private val pkgConfigDir = libDir / "pkgconfig"
+
+  private def baseName(file: java.io.File): String = {
+    val last = file.getName()
+    val li = last.lastIndexOf('.')
+    if (li == -1) last
+    else last.slice(0, li)
+  }
+}

--- a/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgConfigurator.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgConfigurator.scala
@@ -1,6 +1,7 @@
 package com.indoorvivants.vcpkg
 
 import com.indoorvivants.detective.Platform
+import java.io.File
 
 class VcpkgConfigurator(
     config: Vcpkg.Configuration,
@@ -9,12 +10,18 @@ class VcpkgConfigurator(
 ) {
   import config.*
 
-  def files(name: Vcpkg.Dependency) =
+  def dependencyFiles(name: Vcpkg.Dependency) =
     info(name)
 
-  def includes(library: Vcpkg.Dependency) = {
+  def dependencyIncludes(library: Vcpkg.Dependency) = {
     info(library).includeDir
   }
+
+  def files(libraryName: String): Vcpkg.FilesInfo =
+    info(Vcpkg.Dependency(libraryName))
+
+  def includes(libraryName: String): File =
+    info(Vcpkg.Dependency(libraryName)).includeDir
 
   def approximateLinkingArguments = {
     val arguments = Vector.newBuilder[String]

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -8,37 +8,40 @@ scalaVersion := "3.2.0"
 
 import bindgen.interface.Binding
 
-bindgenBindings := Seq(
-  Binding(
-    vcpkgManager.value.includes("cjson") / "cjson" / "cJSON.h",
-    "cjson",
-    cImports = List("cJSON.h")
-  ),
-  Binding(
-    vcpkgManager.value.includes("libuv") / "uv.h",
-    "libuv",
-    cImports = List("uv.h"),
-    clangFlags = List("-I" + vcpkgManager.value.includes("libuv").toString)
-  ),
-  Binding(
-    vcpkgManager.value.includes("czmq") / "czmq.h",
-    "czmq",
-    cImports = List("czmq.h"),
-    clangFlags = List(
-      "-I" + vcpkgManager.value.includes("czmq").toString,
-      "-I" + vcpkgManager.value.includes("zeromq").toString
+bindgenBindings := {
+  val configurator = vcpkgConfigurator.value
+  Seq(
+    Binding(
+      configurator.includes("cjson") / "cjson" / "cJSON.h",
+      "cjson",
+      cImports = List("cJSON.h")
+    ),
+    Binding(
+      configurator.includes("libuv") / "uv.h",
+      "libuv",
+      cImports = List("uv.h"),
+      clangFlags = List("-I" + configurator.includes("libuv").toString)
+    ),
+    Binding(
+      configurator.includes("czmq") / "czmq.h",
+      "czmq",
+      cImports = List("czmq.h"),
+      clangFlags = List(
+        "-I" + configurator.includes("czmq").toString,
+        "-I" + configurator.includes("zeromq").toString
+      )
     )
   )
-)
+}
 
 nativeConfig := {
   import com.indoorvivants.detective.Platform
   val configurator = vcpkgConfigurator.value
-  val manager = vcpkgManager.value
+  val pkgConfig = configurator.pkgConfig
   val conf = nativeConfig.value
   val deps = vcpkgDependencies.value.toSeq
 
-  val files = deps.map(d => manager.files(d))
+  val files = deps.map(d => configurator.files(d))
 
   val compileArgsApprox = files.flatMap { f =>
     List("-I" + f.includeDir.toString)
@@ -51,7 +54,7 @@ nativeConfig := {
 
   def updateLinkingFlags(current: Seq[String], deps: String*) =
     try {
-      configurator.updateLinkingFlags(
+      pkgConfig.updateLinkingFlags(
         current,
         deps *
       )
@@ -62,7 +65,7 @@ nativeConfig := {
 
   def updateCompilationFlags(current: Seq[String], deps: String*) =
     try {
-      configurator.updateCompilationFlags(
+      pkgConfig.updateCompilationFlags(
         current,
         deps *
       )

--- a/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/package.scala
+++ b/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/package.scala
@@ -6,4 +6,6 @@ package object mill {
   implicit val filesInfoRw: ReadWriter[Vcpkg.FilesInfo] =
     implicitly[ReadWriter[MFilesInfo]]
       .bimap(MFilesInfo.fromVcpkgFilesInfo, _.toVcpkgFilesInfo)
+
+  implicit val depRW: upickle.default.ReadWriter[Vcpkg.Dependency] = upickle.default.macroRW[Vcpkg.Dependency]
 }

--- a/mill-plugin/src/test/scala/com/indoorvivants/vcpkg/mill/VcpkgModuleSpec.scala
+++ b/mill-plugin/src/test/scala/com/indoorvivants/vcpkg/mill/VcpkgModuleSpec.scala
@@ -17,8 +17,8 @@ object VcpkgModuleSpec extends utest.TestSuite {
       }
 
       val eval = new TestEvaluator(build)
-      val Right((result, _)) = eval(build.foo.vcpkgCompilationArguments)
-      assert(result.size > 0)
+      val Right((result, _)) = eval(build.foo.vcpkgConfigurator)
+      assert(result.approximateCompilationArguments.size > 0)
     }
 
     test("pkg-config") {
@@ -29,7 +29,8 @@ object VcpkgModuleSpec extends utest.TestSuite {
       }
 
       val eval = new TestEvaluator(build)
-      val Right((pkgConfig, _)) = eval(build.foo.vcpkgConfigurator)
+      val Right((result, _)) = eval(build.foo.vcpkgConfigurator)
+      val pkgConfig = result.pkgConfig
 
       val includes =
         includePaths(pkgConfig.compilationFlags("libcmark", "libcjson"))

--- a/sbt-plugin/src/main/scala/com/indoorvivants/vcpkg/sbt/VcpkgPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/indoorvivants/vcpkg/sbt/VcpkgPlugin.scala
@@ -26,7 +26,12 @@ object VcpkgPlugin extends AutoPlugin with vcpkg.VcpkgPluginImpl {
     )
     val vcpkgManager = taskKey[Vcpkg]("")
     val vcpkgConfigurator = taskKey[vcpkg.VcpkgConfigurator]("")
-    val vcpkgBaseDirectory = taskKey[File]("")
+    val vcpkgBaseDirectory = taskKey[File](
+      "Base folder where sbt-vcpkg will store information: \n " +
+        "- microsoft/vcpkg Github repository will be cloned into `vcpkg` subfolder" +
+        "- packages will be directed to be instealled in the `vcpkg-install` subfolder" +
+        "This folder as a whole is a good candidate for CI caching"
+    )
   }
 
   import autoImport._

--- a/sbt-plugin/src/main/scala/com/indoorvivants/vcpkg/sbt/VcpkgPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/indoorvivants/vcpkg/sbt/VcpkgPlugin.scala
@@ -21,12 +21,12 @@ object VcpkgPlugin extends AutoPlugin with vcpkg.VcpkgPluginImpl {
     val vcpkgBootstrap =
       settingKey[Boolean]("whether to bootstrap vcpkg automatically")
     val vcpkgBinary = taskKey[File]("Path to vcpkg binary")
-    val vcpkgInstall = taskKey[Vector[Vcpkg.FilesInfo]]("Invoke Vcpkg and attempt to install packages")
-    val vcpkgLinkingArguments = taskKey[Vector[String]]("")
-    val vcpkgCompilationArguments = taskKey[Vector[String]]("")
+    val vcpkgInstall = taskKey[Map[Vcpkg.Dependency, Vcpkg.FilesInfo]](
+      "Invoke Vcpkg and attempt to install packages"
+    )
     val vcpkgManager = taskKey[Vcpkg]("")
-    val vcpkgConfigurator = taskKey[vcpkg.PkgConfig]("")
-    val vcpkgBaseDir = taskKey[File]("")
+    val vcpkgConfigurator = taskKey[vcpkg.VcpkgConfigurator]("")
+    val vcpkgBaseDirectory = taskKey[File]("")
   }
 
   import autoImport._
@@ -34,29 +34,30 @@ object VcpkgPlugin extends AutoPlugin with vcpkg.VcpkgPluginImpl {
   override lazy val projectSettings = Seq(
     vcpkgBootstrap := true,
     vcpkgDependencies := Set.empty,
-    vcpkgBaseDir := vcpkgDefaultBaseDir,
+    vcpkgBaseDirectory := vcpkgDefaultBaseDir,
     vcpkgManager := {
       val binary = vcpkgBinary.value
-      val installation = vcpkgBaseDir.value / "vcpkg-install"
-      val logger = sLog.value
-      val errorLogger = (s: String) => logger.error(s)
-      val debugLogger = (s: String) => logger.debug(s)
+      val installation = vcpkgBaseDirectory.value / "vcpkg-install"
 
       VcpkgBootstrap.manager(
         binary,
         installation,
-        errorLogger = errorLogger,
-        debugLogger = debugLogger
+        logger = sbtLogger(sLog.value)
       )
     },
     vcpkgConfigurator := {
-      val _ = vcpkgInstall.value
+      val files = vcpkgInstall.value
+      val manager = vcpkgManager.value
 
-      vcpkgManager.value.pkgConfig
+      new vcpkg.VcpkgConfigurator(
+        manager.config,
+        files,
+        logger = sbtLogger(sLog.value)
+      )
     },
     vcpkgBinary := {
       vcpkgBinaryImpl(
-        targetFolder = vcpkgBaseDir.value,
+        targetFolder = vcpkgBaseDirectory.value,
         logInfo = sLog.value.info(_),
         logError = sLog.value.error(_)
       )
@@ -65,18 +66,7 @@ object VcpkgPlugin extends AutoPlugin with vcpkg.VcpkgPluginImpl {
       vcpkgInstallImpl(
         dependencies = vcpkgDependencies.value,
         manager = vcpkgManager.value,
-        logInfo = sLog.value.info(_)
-      ).toVector
-    },
-    vcpkgLinkingArguments := {
-      vcpkgLinkingArgumentsImpl(
-        info = vcpkgInstall.value,
-        logWarn = sLog.value.error(_)
-      )
-    },
-    vcpkgCompilationArguments := {
-      vcpkgCompilationArgumentsImpl(
-        info = vcpkgInstall.value
+        logger = sbtLogger(sLog.value)
       )
     }
   )
@@ -84,4 +74,13 @@ object VcpkgPlugin extends AutoPlugin with vcpkg.VcpkgPluginImpl {
   override lazy val buildSettings = Seq()
 
   override lazy val globalSettings = Seq()
+
+  private def sbtLogger(logger: sbt.Logger): vcpkg.ExternalLogger = {
+    vcpkg.ExternalLogger(
+      debug = logger.debug(_),
+      info = logger.info(_),
+      warn = logger.warn(_),
+      error = logger.error(_)
+    )
+  }
 }

--- a/sbt-plugin/src/sbt-test/sbt-vcpkg/simple/build.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-vcpkg/simple/build.sbt
@@ -1,5 +1,5 @@
 version := "0.1"
-scalaVersion := "2.12.16"
+scalaVersion := "3.2.0"
 
 enablePlugins(VcpkgPlugin)
 
@@ -10,7 +10,7 @@ vcpkgDependencies := Set("cmark", "cjson")
 val testPkgConfig = taskKey[Unit]("")
 
 testPkgConfig := {
-  val pkgConfig = vcpkgConfigurator.value
+  val pkgConfig = vcpkgConfigurator.value.pkgConfig
 
   val compilation = pkgConfig.compilationFlags("libcmark", "libcjson")
   val linking = pkgConfig.linkingFlags("libcmark", "libcjson")

--- a/sbt-plugin/src/sbt-test/sbt-vcpkg/simple/test
+++ b/sbt-plugin/src/sbt-test/sbt-vcpkg/simple/test
@@ -1,3 +1,1 @@
-> vcpkgCompilationArguments
-> vcpkgLinkingArguments
 > testPkgConfig


### PR DESCRIPTION
1. Use ExternalLogger interface
2. Remove configuration methods from Vcpkg manager - it now only deals with packages and installation
3. VcpkgConfigurator is now the big dog for various linking arguments and such.

This should close #37 in a better way, and also tighten the interfaces quite a bit.