### PR TITLE
Don't re-install already installed dependencies

### DIFF
--- a/core/src/main/scala/com/indoorvivants/vcpkg/Configuration.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/Configuration.scala
@@ -1,0 +1,47 @@
+package com.indoorvivants.vcpkg
+
+import com.indoorvivants.detective.Platform
+import java.io.File
+
+case class Configuration(
+    binary: File,
+    installationDir: File,
+    linking: Linking
+) {
+  def vcpkgRoot: File = binary.getParentFile()
+  def vcpkgTriplet(target: Platform.Target): String = {
+    import Platform.Arch.*
+    import Platform.OS.*
+    import Platform.Bits
+
+    import target.*
+
+    val archPrefix = arch match {
+      case Intel =>
+        Platform.bits match {
+          case Bits.x32 => "x86"
+          case Bits.x64 => "x64"
+        }
+      case Arm =>
+        Platform.bits match {
+          case Bits.x32 => "arm32"
+          case Bits.x64 => "arm64"
+        }
+    }
+
+    val osName = os match {
+      case Linux   => "linux"
+      case MacOS   => "osx"
+      case Windows => "windows"
+    }
+
+    val lnk = (linking, os) match {
+      case (Linking.Static, Windows)        => Some("static")
+      case (Linking.Dynamic, Linux | MacOS) => Some("dynamic")
+      case _                                => None
+    }
+
+    (archPrefix :: osName :: lnk.toList).mkString("-")
+  }
+
+}

--- a/core/src/main/scala/com/indoorvivants/vcpkg/Dependencies.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/Dependencies.scala
@@ -1,0 +1,39 @@
+package com.indoorvivants.vcpkg
+
+case class Dependencies(packages: Map[Dependency, List[Dependency]]) {
+
+  def allTransitive(name: Dependency): List[Dependency] = {
+    def go(lib: Dependency): List[Dependency] =
+      packages
+        .collectFirst {
+          case (dep, rest) if dep.name == lib.name => rest
+        }
+        .getOrElse(Nil)
+        .flatMap { lb =>
+          lb :: go(lb) // TODO: deal with circular dependencies?
+        }
+        .distinct
+
+    go(name)
+  }
+}
+object Dependencies {
+  def parse(lines: Vector[String]): Dependencies = {
+    Dependencies(lines.map { l =>
+      if (l.toLowerCase.contains("a suitable version of cmake"))
+        throw NoSuitableCmake
+      else {
+        l.split(": ", 2).toList match {
+          case name :: deps :: Nil =>
+            Dependency
+              .parse(name) -> deps
+              .split(", ")
+              .toList
+              .filterNot(_.trim.isEmpty)
+              .map(Dependency.parse)
+          case other => throw UnexpectedDependencyInfo(l)
+        }
+      }
+    }.toMap)
+  }
+}

--- a/core/src/main/scala/com/indoorvivants/vcpkg/Dependency.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/Dependency.scala
@@ -1,0 +1,18 @@
+package com.indoorvivants.vcpkg
+
+case class Dependency(name: String, features: List[String]) {
+  val short = s"$name${features.mkString("[", ",", "]")}"
+}
+object Dependency {
+  def apply(name: String): Dependency = new Dependency(name, features = Nil)
+  def parse(s: String): Dependency =
+    if (!s.contains('[')) Dependency(s, Nil)
+    else {
+      val start = s.indexOf('[')
+      val end = s.indexOf(']')
+      val features = s.substring(start + 1, end).split(", ").toList
+      val name = s.take(start - 1)
+
+      Dependency(name, features)
+    }
+}

--- a/core/src/main/scala/com/indoorvivants/vcpkg/FilesInfo.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/FilesInfo.scala
@@ -1,0 +1,72 @@
+package com.indoorvivants.vcpkg
+
+import com.indoorvivants.detective.Platform
+import java.io.File
+import java.util.stream.Collectors
+import java.nio.file.Files
+
+case class FilesInfo(includeDir: File, libDir: File) {
+  import collection.JavaConverters._
+  private def walk(
+      path: java.nio.file.Path,
+      predicate: java.nio.file.Path => Boolean
+  ): Vector[File] =
+    if (path.toFile().isDirectory)
+      Files
+        .walk(path)
+        .filter(p => predicate(p))
+        .collect(Collectors.toList())
+        .asScala
+        .toList
+        .map(_.toFile)
+        .toVector
+    else Vector.empty
+
+  def staticLibraries = {
+    walk(
+      libDir.toPath,
+      _.getFileName.toString.endsWith(FilesInfo.staticLibExtension)
+    )
+  }
+
+  def dynamicLibraries = {
+    walk(
+      libDir.toPath,
+      _.getFileName.toString.endsWith(FilesInfo.dynamicLibExtension)
+    )
+  }
+
+  def pkgConfigDir = libDir / "pkgconfig"
+}
+
+object FilesInfo {
+  import Platform.OS._
+  lazy val dynamicLibExtension = Platform.os match {
+    case Linux | Unknown => ".so"
+    case MacOS           => ".dylib"
+    case Windows         => ".dll"
+  }
+
+  lazy val staticLibExtension = Platform.os match {
+    case Windows => ".lib"
+    case _       => ".a"
+  }
+
+  def dynamicLibName(name: String) = {
+    val base = Platform.os match {
+      case Linux | Unknown | MacOS => "lib" + name
+      case Windows                 => name
+    }
+
+    base + dynamicLibExtension
+  }
+
+  def staticLibName(name: String) = {
+    val base = Platform.os match {
+      case Linux | Unknown | MacOS => "lib" + name
+      case Windows                 => name
+    }
+
+    base + staticLibExtension
+  }
+}

--- a/core/src/main/scala/com/indoorvivants/vcpkg/InstalledList.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/InstalledList.scala
@@ -1,0 +1,24 @@
+package com.indoorvivants.vcpkg
+
+import scala.collection.immutable
+
+case class InstalledList private (deps: Vector[Dependency])
+
+object InstalledList {
+  def parse(lines: Vector[String], logger: ExternalLogger) = {
+    val parsed = lines.flatMap { line =>
+      val dep = line.takeWhile(!_.isWhitespace).trim
+      dep.split(":").toList match {
+        case head :: next =>
+          Some(Dependency.parse(head))
+        case immutable.Nil =>
+          logger.warn(s"Failed to parse `$dep` as installed dependency")
+
+          None
+      }
+
+    }
+
+    new InstalledList(parsed)
+  }
+}

--- a/core/src/main/scala/com/indoorvivants/vcpkg/Linking.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/Linking.scala
@@ -1,0 +1,7 @@
+package com.indoorvivants.vcpkg
+
+sealed trait Linking
+object Linking {
+  case object Static extends Linking
+  case object Dynamic extends Linking
+}

--- a/core/src/main/scala/com/indoorvivants/vcpkg/Logs.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/Logs.scala
@@ -1,0 +1,48 @@
+package com.indoorvivants.vcpkg
+
+case class Logs(
+    logger: sys.process.ProcessLogger,
+    stdout: () => Vector[String],
+    stderr: () => Vector[String]
+) {
+  def dump(to: String => Unit) = {
+    stdout().foreach(s => to(s"[vcpkg stdout] $s"))
+    stderr().foreach(s => to(s"[vcpkg stderr] $s"))
+  }
+}
+
+object Logs {
+  sealed trait Collect extends Product with Serializable
+  case object Buffer extends Collect
+  case class Redirect(to: String => Unit) extends Collect
+
+  def logCollector(
+      out: Set[Logs.Collect] = Set(Logs.Buffer),
+      err: Set[Logs.Collect] = Set(Logs.Buffer)
+  ) = {
+    val stdout = Vector.newBuilder[String]
+    val stderr = Vector.newBuilder[String]
+
+    def handle(msg: String, c: Logs.Collect, buffer: String => Unit) =
+      c match {
+        case Buffer       => buffer(msg)
+        case Redirect(to) => to(msg)
+      }
+
+    val logger = sys.process.ProcessLogger.apply(
+      (o: String) => {
+        out.foreach { collector =>
+          handle(o, collector, stdout.+=(_))
+
+        }
+      },
+      (e: String) =>
+        out.foreach { collector =>
+          handle(e, collector, stderr.+=(_))
+        }
+    )
+
+    Logs(logger, () => stdout.result(), () => stderr.result())
+  }
+
+}

--- a/core/src/main/scala/com/indoorvivants/vcpkg/PkgConfig.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/PkgConfig.scala
@@ -21,7 +21,7 @@ class PkgConfig(baseDir: File, logger: ExternalLogger) {
 
   private def getLines(args: Seq[String]) = {
     import sys.process.Process
-    val logs = Vcpkg.logCollector()
+    val logs = Logs.logCollector()
     val p = Process
       .apply(args, cwd = None, extraEnv = env.toSeq *)
       .run(logs.logger)

--- a/core/src/main/scala/com/indoorvivants/vcpkg/Vcpkg.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/Vcpkg.scala
@@ -5,13 +5,13 @@ import scala.sys.process
 import java.io.File
 import java.nio.file.Files
 import java.util.stream.Collectors
-import com.indoorvivants.vcpkg.Vcpkg.Logs.Buffer
-import com.indoorvivants.vcpkg.Vcpkg.Logs.Redirect
+import com.indoorvivants.vcpkg.Logs.Buffer
+import com.indoorvivants.vcpkg.Logs.Redirect
 
 import com.indoorvivants.detective.Platform
 
 class Vcpkg(
-    val config: Vcpkg.Configuration,
+    val config: Configuration,
     logger: ExternalLogger
 ) {
   import sys.process.*
@@ -29,9 +29,9 @@ class Vcpkg(
 
   private def getLines(args: Seq[String]): Vector[String] = {
     import sys.process.Process
-    val logs = Vcpkg.logCollector(
-      out = Set(Vcpkg.Logs.Buffer, Vcpkg.Logs.Redirect(logger.debug)),
-      err = Set(Vcpkg.Logs.Buffer, Vcpkg.Logs.Redirect(logger.debug))
+    val logs = Logs.logCollector(
+      out = Set(Logs.Buffer, Logs.Redirect(logger.debug)),
+      err = Set(Logs.Buffer, Logs.Redirect(logger.debug))
     )
     val p = Process.apply(args, cwd = root).run(logs.logger).exitValue()
 
@@ -44,226 +44,13 @@ class Vcpkg(
     }
   }
 
-  def dependencyInfo(name: String): Vcpkg.Dependencies =
-    Vcpkg.Dependencies.parse(getLines(cmd("depend-info", name)))
+  def dependencyInfo(name: String): Dependencies =
+    Dependencies.parse(getLines(cmd("depend-info", name)))
 
   def install(name: String): Vector[String] =
     getLines(cmd("install", name, s"--triplet=$vcpkgTriplet", "--recurse"))
 
-}
-
-object Vcpkg {
-  sealed trait Linking
-  object Linking {
-    case object Static extends Linking
-    case object Dynamic extends Linking
-  }
-  case class Configuration(
-      binary: File,
-      installationDir: File,
-      linking: Linking
-  ) {
-    def vcpkgRoot: File = binary.getParentFile()
-    def vcpkgTriplet(target: Platform.Target): String = {
-      import Platform.Arch.*
-      import Platform.OS.*
-      import Platform.Bits
-
-      import target.*
-
-      val archPrefix = arch match {
-        case Intel =>
-          Platform.bits match {
-            case Bits.x32 => "x86"
-            case Bits.x64 => "x64"
-          }
-        case Arm =>
-          Platform.bits match {
-            case Bits.x32 => "arm32"
-            case Bits.x64 => "arm64"
-          }
-      }
-
-      val osName = os match {
-        case Linux   => "linux"
-        case MacOS   => "osx"
-        case Windows => "windows"
-      }
-
-      val lnk = (linking, os) match {
-        case (Vcpkg.Linking.Static, Windows)        => Some("static")
-        case (Vcpkg.Linking.Dynamic, Linux | MacOS) => Some("dynamic")
-        case _                                      => None
-      }
-
-      (archPrefix :: osName :: lnk.toList).mkString("-")
-    }
-
-  }
-
-  case class Dependency(name: String, features: List[String])
-  object Dependency {
-    def apply(name: String): Dependency = new Dependency(name, features = Nil)
-    def parse(s: String): Dependency =
-      if (!s.contains('[')) Dependency(s, Nil)
-      else {
-        val start = s.indexOf('[')
-        val end = s.indexOf(']')
-        val features = s.substring(start + 1, end).split(", ").toList
-        val name = s.take(start - 1)
-
-        Dependency(name, features)
-      }
-  }
-
-  case class Dependencies(packages: Map[Dependency, List[Dependency]]) {
-
-    def allTransitive(name: Dependency): List[Dependency] = {
-      def go(lib: Dependency): List[Dependency] =
-        packages
-          .collectFirst {
-            case (dep, rest) if dep.name == lib.name => rest
-          }
-          .getOrElse(Nil)
-          .flatMap { lb =>
-            lb :: go(lb) // TODO: deal with circular dependencies?
-          }
-          .distinct
-
-      go(name)
-    }
-  }
-  object Dependencies {
-    def parse(lines: Vector[String]): Dependencies = {
-      Dependencies(lines.map { l =>
-        if (l.toLowerCase.contains("a suitable version of cmake"))
-          throw NoSuitableCmake
-        else {
-          l.split(": ", 2).toList match {
-            case name :: deps :: Nil =>
-              Dependency
-                .parse(name) -> deps
-                .split(", ")
-                .toList
-                .filterNot(_.trim.isEmpty)
-                .map(Dependency.parse)
-            case other => throw UnexpectedDependencyInfo(l)
-          }
-        }
-      }.toMap)
-    }
-  }
-
-  case class FilesInfo(includeDir: File, libDir: File) {
-    import collection.JavaConverters._
-    private def walk(
-        path: java.nio.file.Path,
-        predicate: java.nio.file.Path => Boolean
-    ): Vector[File] =
-      if (path.toFile().isDirectory)
-        Files
-          .walk(path)
-          .filter(p => predicate(p))
-          .collect(Collectors.toList())
-          .asScala
-          .toList
-          .map(_.toFile)
-          .toVector
-      else Vector.empty
-
-    def staticLibraries = {
-      walk(
-        libDir.toPath,
-        _.getFileName.toString.endsWith(FilesInfo.staticLibExtension)
-      )
-    }
-
-    def dynamicLibraries = {
-      walk(
-        libDir.toPath,
-        _.getFileName.toString.endsWith(FilesInfo.dynamicLibExtension)
-      )
-    }
-
-    def pkgConfigDir = libDir / "pkgconfig"
-  }
-
-  object FilesInfo {
-    import Platform.OS._
-    lazy val dynamicLibExtension = Platform.os match {
-      case Linux | Unknown => ".so"
-      case MacOS           => ".dylib"
-      case Windows         => ".dll"
-    }
-
-    lazy val staticLibExtension = Platform.os match {
-      case Windows => ".lib"
-      case _       => ".a"
-    }
-
-    def dynamicLibName(name: String) = {
-      val base = Platform.os match {
-        case Linux | Unknown | MacOS => "lib" + name
-        case Windows                 => name
-      }
-
-      base + dynamicLibExtension
-    }
-
-    def staticLibName(name: String) = {
-      val base = Platform.os match {
-        case Linux | Unknown | MacOS => "lib" + name
-        case Windows                 => name
-      }
-
-      base + staticLibExtension
-    }
-  }
-
-  case class Logs(
-      logger: process.ProcessLogger,
-      stdout: () => Vector[String],
-      stderr: () => Vector[String]
-  ) {
-    def dump(to: String => Unit) = {
-      stdout().foreach(s => to(s"[vcpkg stdout] $s"))
-      stderr().foreach(s => to(s"[vcpkg stderr] $s"))
-    }
-  }
-
-  object Logs {
-    sealed trait Collect extends Product with Serializable
-    case object Buffer extends Collect
-    case class Redirect(to: String => Unit) extends Collect
-  }
-
-  def logCollector(
-      out: Set[Logs.Collect] = Set(Logs.Buffer),
-      err: Set[Logs.Collect] = Set(Logs.Buffer)
-  ) = {
-    val stdout = Vector.newBuilder[String]
-    val stderr = Vector.newBuilder[String]
-
-    def handle(msg: String, c: Logs.Collect, buffer: String => Unit) =
-      c match {
-        case Buffer       => buffer(msg)
-        case Redirect(to) => to(msg)
-      }
-
-    val logger = process.ProcessLogger.apply(
-      (o: String) => {
-        out.foreach { collector =>
-          handle(o, collector, stdout.+=(_))
-
-        }
-      },
-      (e: String) =>
-        out.foreach { collector =>
-          handle(e, collector, stderr.+=(_))
-        }
-    )
-
-    Logs(logger, () => stdout.result(), () => stderr.result())
-  }
+  def list(): Vector[String] =
+    getLines(cmd("list", s"--triplet=$vcpkgTriplet"))
 
 }

--- a/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgBootstrap.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgBootstrap.scala
@@ -45,7 +45,7 @@ object VcpkgBootstrap {
     )
     import sys.process._
 
-    val collector = Vcpkg.logCollector()
+    val collector = Logs.logCollector()
 
     val cmd = Seq(script.toString)
 
@@ -65,10 +65,10 @@ object VcpkgBootstrap {
       s"vcpkg executable ($binary) doesn't exist, did you forget to bootstrap it"
     )
 
-    val config = Vcpkg.Configuration(
+    val config = Configuration(
       binary = binary,
       installationDir = installationDir,
-      linking = Vcpkg.Linking.Static
+      linking = Linking.Static
     )
 
     new Vcpkg(config, logger)

--- a/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgConfigurator.scala
+++ b/core/src/main/scala/com/indoorvivants/vcpkg/VcpkgConfigurator.scala
@@ -4,29 +4,29 @@ import com.indoorvivants.detective.Platform
 import java.io.File
 
 class VcpkgConfigurator(
-    config: Vcpkg.Configuration,
-    info: Map[Vcpkg.Dependency, Vcpkg.FilesInfo],
+    config: Configuration,
+    info: Map[Dependency, FilesInfo],
     logger: ExternalLogger
 ) {
   import config.*
 
-  def dependencyFiles(name: Vcpkg.Dependency) =
+  def dependencyFiles(name: Dependency) =
     info(name)
 
-  def dependencyIncludes(library: Vcpkg.Dependency) = {
+  def dependencyIncludes(library: Dependency) = {
     info(library).includeDir
   }
 
-  def files(libraryName: String): Vcpkg.FilesInfo =
-    info(Vcpkg.Dependency(libraryName))
+  def files(libraryName: String): FilesInfo =
+    info(Dependency(libraryName))
 
   def includes(libraryName: String): File =
-    info(Vcpkg.Dependency(libraryName)).includeDir
+    info(Dependency(libraryName)).includeDir
 
   def approximateLinkingArguments = {
     val arguments = Vector.newBuilder[String]
 
-    sorted.foreach { case (name, f @ Vcpkg.FilesInfo(_, libDir)) =>
+    sorted.foreach { case (name, f @ FilesInfo(_, libDir)) =>
       val static = f.staticLibraries
       val dynamic = f.dynamicLibraries
 
@@ -52,7 +52,7 @@ class VcpkgConfigurator(
   def approximateCompilationArguments = {
     val arguments = Vector.newBuilder[String]
 
-    sorted.foreach { case (_, f @ Vcpkg.FilesInfo(includeDir, _)) =>
+    sorted.foreach { case (_, f @ FilesInfo(includeDir, _)) =>
       arguments += s"-I$includeDir"
     }
 

--- a/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/MFilesInfo.scala
+++ b/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/MFilesInfo.scala
@@ -1,16 +1,17 @@
-package com.indoorvivants.vcpkg.mill
+package com.indoorvivants.vcpkg.millplugin
 
 import mill._
 import upickle.default._
 import com.indoorvivants.vcpkg.Vcpkg
+import com.indoorvivants.vcpkg._
 
 private[vcpkg] case class MFilesInfo(includeDir: PathRef, libDir: PathRef) {
-  def toVcpkgFilesInfo: Vcpkg.FilesInfo =
-    Vcpkg.FilesInfo(includeDir.path.toIO, libDir.path.toIO)
+  def toVcpkgFilesInfo: FilesInfo =
+    FilesInfo(includeDir.path.toIO, libDir.path.toIO)
 }
 
 private[vcpkg] object MFilesInfo {
-  def fromVcpkgFilesInfo(filesInfo: Vcpkg.FilesInfo): MFilesInfo =
+  def fromVcpkgFilesInfo(filesInfo: FilesInfo): MFilesInfo =
     MFilesInfo(
       PathRef(os.Path(filesInfo.includeDir)),
       PathRef(os.Path(filesInfo.libDir))

--- a/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/VcpkgModule.scala
+++ b/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/VcpkgModule.scala
@@ -1,8 +1,8 @@
-package com.indoorvivants.vcpkg.mill
+package com.indoorvivants.vcpkg.millplugin
 
 import com.indoorvivants.vcpkg.PkgConfig
 import com.indoorvivants.detective.Platform.OS._
-import com.indoorvivants.vcpkg.Vcpkg
+import com.indoorvivants.vcpkg
 import com.indoorvivants.vcpkg.VcpkgBootstrap
 import com.indoorvivants.vcpkg.VcpkgPluginImpl
 import mill._
@@ -48,13 +48,13 @@ trait VcpkgModule extends mill.define.Module with VcpkgPluginImpl {
     os.Path(ioFile)
   }
 
-  def vcpkgManager: Worker[Vcpkg] = T.worker {
+  def vcpkgManager: Worker[vcpkg.Vcpkg] = T.worker {
     val binary = vcpkgBinary().toIO
     val installation = vcpkgBaseDirectory() / "vcpkg-install"
     VcpkgBootstrap.manager(binary, installation.toIO, millLogger(T.log))
   }
 
-  def vcpkgInstall: T[Map[Vcpkg.Dependency, Vcpkg.FilesInfo]] = T {
+  def vcpkgInstall: T[Map[vcpkg.Dependency, vcpkg.FilesInfo]] = T {
     vcpkgInstallImpl(
       dependencies = vcpkgDependencies(),
       manager = vcpkgManager(),

--- a/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/package.scala
+++ b/mill-plugin/src/main/scala/com/indoorvivants/vcpkg/mill/package.scala
@@ -2,10 +2,11 @@ package com.indoorvivants.vcpkg
 
 import upickle.default._
 
-package object mill {
-  implicit val filesInfoRw: ReadWriter[Vcpkg.FilesInfo] =
+package object millplugin {
+  implicit val filesInfoRw: ReadWriter[FilesInfo] =
     implicitly[ReadWriter[MFilesInfo]]
       .bimap(MFilesInfo.fromVcpkgFilesInfo, _.toVcpkgFilesInfo)
 
-  implicit val depRW: upickle.default.ReadWriter[Vcpkg.Dependency] = upickle.default.macroRW[Vcpkg.Dependency]
+  implicit val depRW: upickle.default.ReadWriter[Dependency] =
+    upickle.default.macroRW[Dependency]
 }

--- a/mill-plugin/src/test/scala/com/indoorvivants/vcpkg/mill/VcpkgModuleSpec.scala
+++ b/mill-plugin/src/test/scala/com/indoorvivants/vcpkg/mill/VcpkgModuleSpec.scala
@@ -1,10 +1,10 @@
-package com.indoorvivants.vcpkg.mill
+package com.indoorvivants.vcpkg.millplugin
 
 import utest._
 import mill._
 import mill.util.TestEvaluator
 import mill.util.TestUtil
-import com.indoorvivants.vcpkg.Vcpkg
+import com.indoorvivants.vcpkg._
 
 object VcpkgModuleSpec extends utest.TestSuite {
 
@@ -19,6 +19,7 @@ object VcpkgModuleSpec extends utest.TestSuite {
       val eval = new TestEvaluator(build)
       val Right((result, _)) = eval(build.foo.vcpkgConfigurator)
       assert(result.approximateCompilationArguments.size > 0)
+      assert(result.approximateLinkingArguments.size > 0)
     }
 
     test("pkg-config") {
@@ -45,15 +46,15 @@ object VcpkgModuleSpec extends utest.TestSuite {
 
       assert(
         paths.exists { p =>
-          (p / Vcpkg.FilesInfo.dynamicLibName("cmark")).toIO.exists() ||
-          (p / Vcpkg.FilesInfo.staticLibName("cmark")).toIO.exists() ||
-          (p / Vcpkg.FilesInfo.staticLibName("cmark_static")).toIO.exists()
+          (p / FilesInfo.dynamicLibName("cmark")).toIO.exists() ||
+          (p / FilesInfo.staticLibName("cmark")).toIO.exists() ||
+          (p / FilesInfo.staticLibName("cmark_static")).toIO.exists()
         }
       )
       assert(
         paths.exists { p =>
-          (p / Vcpkg.FilesInfo.dynamicLibName("cjson")).toIO.exists() ||
-          (p / Vcpkg.FilesInfo.staticLibName("cjson")).toIO.exists()
+          (p / FilesInfo.dynamicLibName("cjson")).toIO.exists() ||
+          (p / FilesInfo.staticLibName("cjson")).toIO.exists()
         }
       )
 

--- a/sbt-plugin/src/main/scala/com/indoorvivants/vcpkg/sbt/VcpkgPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/indoorvivants/vcpkg/sbt/VcpkgPlugin.scala
@@ -1,4 +1,4 @@
-package com.indoorvivants.vcpkg.sbt
+package com.indoorvivants.vcpkg.sbtplugin
 
 import com.indoorvivants.vcpkg
 import com.indoorvivants.detective.Platform.OS._
@@ -21,7 +21,7 @@ object VcpkgPlugin extends AutoPlugin with vcpkg.VcpkgPluginImpl {
     val vcpkgBootstrap =
       settingKey[Boolean]("whether to bootstrap vcpkg automatically")
     val vcpkgBinary = taskKey[File]("Path to vcpkg binary")
-    val vcpkgInstall = taskKey[Map[Vcpkg.Dependency, Vcpkg.FilesInfo]](
+    val vcpkgInstall = taskKey[Map[vcpkg.Dependency, vcpkg.FilesInfo]](
       "Invoke Vcpkg and attempt to install packages"
     )
     val vcpkgManager = taskKey[Vcpkg]("")

--- a/sbt-plugin/src/sbt-test/sbt-vcpkg/simple/build.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-vcpkg/simple/build.sbt
@@ -3,7 +3,7 @@ scalaVersion := "3.2.0"
 
 enablePlugins(VcpkgPlugin)
 
-import com.indoorvivants.vcpkg.Vcpkg
+import com.indoorvivants.vcpkg
 
 vcpkgDependencies := Set("cmark", "cjson")
 
@@ -28,14 +28,14 @@ testPkgConfig := {
 
   assert(
     paths.exists { p =>
-      (p / Vcpkg.FilesInfo.dynamicLibName("cmark")).exists() ||
-      (p / Vcpkg.FilesInfo.staticLibName("cmark")).exists()
+      (p / vcpkg.FilesInfo.dynamicLibName("cmark")).exists() ||
+      (p / vcpkg.FilesInfo.staticLibName("cmark")).exists()
     }
   )
   assert(
     paths.exists { p =>
-      (p / Vcpkg.FilesInfo.dynamicLibName("cjson")).exists() ||
-      (p / Vcpkg.FilesInfo.staticLibName("cjson")).exists()
+      (p / vcpkg.FilesInfo.dynamicLibName("cjson")).exists() ||
+      (p / vcpkg.FilesInfo.staticLibName("cjson")).exists()
     }
   )
 


### PR DESCRIPTION
Closes #10 

It breaks everything, but hey, it's 0.0.x

Also:
- Remove top-level Vcpkg object + move build tool packages
- .sbt and .mill cause issues with wildcard imports in buildfiles